### PR TITLE
Show current date in trend

### DIFF
--- a/src/FutureTrend.php
+++ b/src/FutureTrend.php
@@ -74,7 +74,7 @@ abstract class FutureTrend extends Trend
                 return $now->startOfWeek()->setTime(0, 0);
 
             case 'day':
-                return $now->setTime(0, 0);
+                return $now->subDay()->setTime(0, 0);
 
             case 'hour':
                 return with($now->addHours(24), function ($now) {


### PR DESCRIPTION
Right now the generated trend does not include the current date in the graph. This changes this so that it is shown.